### PR TITLE
Set up dev environment + add Cursor Cloud instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single-page React + TypeScript portfolio built with Vite (see `README.md` for the canonical command list). There is no monorepo, database, auth, or external service — the only "backend" is the contact form endpoint.
+
+### Services
+
+| Service | Command | Notes |
+|---------|---------|-------|
+| Vite dev server (SPA + contact API stub) | `npm run dev` | Serves at `http://localhost:5173`. Includes a built-in dev middleware for `POST /api/contact`, so the contact form works without Vercel. This is the only service needed to exercise the whole site. |
+| Vercel-parity API (optional) | `npm run dev:vercel` | Runs the real `api/contact.ts` serverless function via `vercel dev`. Only needed for production-parity API testing; requires the Vercel CLI. |
+
+### Node version (non-obvious)
+
+- The app targets Node 24 (`package.json` `engines`, `.nvmrc`). The VM's default on-PATH `node` (`/exec-daemon/node`) is v22, which takes PATH precedence over nvm.
+- Node 24 is installed via `nvm` and login/interactive shells default to it (configured in `~/.bashrc`). If you spawn a non-login shell and need Node 24 explicitly, run `nvm use 24` or prepend `"$NVM_DIR/versions/node/v24.17.0/bin"` to `PATH`. Node 22 also builds/runs this app fine.
+
+### Build / run
+
+- Build: `npm run build` (runs `tsc -p tsconfig.app.json` then `vite build`, output `dist/`). Verified working.
+- Preview production build: `npm run preview`.
+
+### Lint (pre-existing breakage)
+
+- `npm run lint` currently fails: ESLint 9 requires an `eslint.config.js` (flat config) but no ESLint config file exists in the repo. This is a repository issue, not an environment problem — do not "fix" it as part of environment setup.
+
+### Notes
+
+- `next.config.mjs` is vestigial; there is no `next` dependency. The project is purely Vite + React.
+- The contact form is a stub: it validates input and logs to the server console (visible in the `npm run dev` output) but does not send email. Planned env vars `CONTACT_TO_EMAIL` / `RESEND_API_KEY` are not yet wired up.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up the development environment for this React + Vite portfolio site and verified it end-to-end. Added `AGENTS.md` with Cursor Cloud specific instructions.

## Environment setup

- Installed Node 24 (matches `package.json` `engines` / `.nvmrc`) via `nvm`; login shells now default to it (the VM's default on-PATH node is v22).
- Installed dependencies with `npm ci`.
- Update script (run on VM startup): `npm install`.

## Verification

- `npm run build` — succeeds (`dist/` output).
- `npm run dev` — serves at `http://localhost:5173` with the built-in `/api/contact` dev stub.
- Hello-world: submitted the contact form end-to-end via the browser and via `curl`; server logged the submission and returned a success response.
- `npm run lint` — fails (pre-existing repo issue: no `eslint.config.js` for ESLint 9). Not fixed as it is out of scope for environment setup.

[portfolio_contact_form_demo.mp4](https://cursor.com/agents/bc-e3dec700-7106-4130-84ec-afed3493c3cf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_contact_form_demo.mp4)

[Contact form success message](https://cursor.com/agents/bc-e3dec700-7106-4130-84ec-afed3493c3cf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_contact_success.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e3dec700-7106-4130-84ec-afed3493c3cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e3dec700-7106-4130-84ec-afed3493c3cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

