### PR TITLE
Wire contact form to Resend for email delivery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Resend API key — create at https://resend.com/api-keys
+RESEND_API_KEY=re_xxxxxxxxxxxxxxxxxxxxxxxx
+
+# Your inbox — where contact form submissions are delivered
+CONTACT_TO_EMAIL=you@example.com
+
+# Verified sender address in Resend (must use a domain you verified at https://resend.com/domains)
+# Example for dtriv.tech after domain verification:
+# CONTACT_FROM_EMAIL=Portfolio Contact <contact@dtriv.tech>
+#
+# For quick local testing only, Resend allows onboarding@resend.dev (sends only to your Resend account email):
+# CONTACT_FROM_EMAIL=Portfolio Contact <onboarding@resend.dev>
+
+# Optional: public email shown in the contact section mailto link
+VITE_CONTACT_EMAIL=hello@dtriv.tech

--- a/README.md
+++ b/README.md
@@ -33,23 +33,34 @@ npm run build
 npm run preview
 ```
 
-### Contact form stub
+### Contact form
 
-The client posts to `/api/contact`.
+The client posts to `/api/contact`. Submissions are delivered to your inbox via [Resend](https://resend.com), which works well with Vercel serverless functions (no SMTP, good deliverability, simple API).
 
-Current behavior:
+**Setup**
 
-- validates payload server-side (name, email, message length limits)
-- silently accepts honeypot submissions (`website` field)
-- logs valid submissions in server output
-- returns a success response without sending email
-
-Planned environment variables for real email delivery (set in Vercel project settings, never in client code):
+1. Create a free [Resend](https://resend.com) account.
+2. Add and verify your domain (e.g. `dtriv.tech`) under [Domains](https://resend.com/domains).
+3. Create an API key under [API Keys](https://resend.com/api-keys).
+4. In your Vercel project → **Settings → Environment Variables**, add:
 
 | Variable | Purpose |
 |----------|---------|
-| `CONTACT_TO_EMAIL` | Inbox that receives form submissions |
 | `RESEND_API_KEY` | Resend API key for outbound email |
+| `CONTACT_TO_EMAIL` | Your inbox — where form submissions are delivered |
+| `CONTACT_FROM_EMAIL` | Verified sender, e.g. `Portfolio Contact <contact@dtriv.tech>` |
+| `VITE_CONTACT_EMAIL` | Optional — email shown in the contact section mailto link |
+
+5. Redeploy after adding env vars.
+
+For local testing, copy `.env.example` to `.env.local` and run `npm run dev:vercel` (Vite dev uses the same handler but needs env vars loaded by Vercel CLI).
+
+**Behavior**
+
+- validates payload server-side (name, email, message length limits)
+- silently accepts honeypot submissions (`website` field)
+- sends email via Resend with `replyTo` set to the visitor's address
+- returns a friendly error if email delivery is not configured
 
 ### Deploy (Vercel)
 
@@ -72,7 +83,7 @@ After deploy, verify on desktop and at 375px width:
 - [ ] Nav links scroll to `#home`, `#work`, `#testimonials`, `#contact`
 - [ ] Mobile hamburger opens/closes; Escape closes menu
 - [ ] Work timeline cards expand on click
-- [ ] Contact form POST returns success message
+- [ ] Contact form POST delivers email to your inbox (requires Resend env vars)
 - [ ] CV link opens (`/cv-placeholder.txt` until real PDF is added)
 - [ ] LinkedIn link opens in new tab
 - [ ] `prefers-reduced-motion: reduce` disables hero motion and marquee

--- a/api/contact.ts
+++ b/api/contact.ts
@@ -1,63 +1,19 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { handleContactSubmission, type ContactPayload } from '../lib/contactHandler';
 
-/**
- * Contact form handler (v1 stub).
- *
- * TODO: Wire real email delivery via Resend or SendGrid:
- *   - RESEND_API_KEY — API key from Resend dashboard
- *   - CONTACT_TO_EMAIL — inbox that receives form submissions
- *
- * TODO: Add rate limiting (e.g. @upstash/ratelimit or Vercel KV) before production traffic.
- * TODO: Consider CAPTCHA if spam becomes an issue.
- */
-
-type ContactPayload = {
-  name?: string;
-  email?: string;
-  message?: string;
-  website?: string;
-};
-
-const isValid = (value: unknown, min = 1, max = 5000) =>
-  typeof value === 'string' && value.trim().length >= min && value.trim().length <= max;
-
-const handleContactSubmission = (payload: ContactPayload) => {
-  if (payload.website) {
-    return { status: 200, body: { ok: true, message: 'Message received.' } };
-  }
-
-  if (
-    !isValid(payload.name, 2, 80) ||
-    !isValid(payload.email, 5, 180) ||
-    !isValid(payload.message, 10, 4000)
-  ) {
-    return {
-      status: 400,
-      body: { ok: false, message: 'Please provide valid contact details.' },
-    };
-  }
-
-  console.log('Contact form stub submission:', {
-    name: payload.name,
-    email: payload.email,
-    message: payload.message,
-    receivedAt: new Date().toISOString(),
-  });
-
-  return {
-    status: 200,
-    body: {
-      ok: true,
-      message: 'Email delivery not configured yet. Your message was captured in the server log.',
-    },
-  };
-};
-
-export default function handler(req: VercelRequest, res: VercelResponse) {
+export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') {
     return res.status(405).json({ ok: false, message: 'Method not allowed' });
   }
 
-  const result = handleContactSubmission((req.body ?? {}) as ContactPayload);
-  return res.status(result.status).json(result.body);
+  try {
+    const result = await handleContactSubmission((req.body ?? {}) as ContactPayload);
+    return res.status(result.status).json(result.body);
+  } catch (error) {
+    console.error('Contact form handler error:', error);
+    return res.status(500).json({
+      ok: false,
+      message: 'Unable to send your message right now. Please try again or email me directly.',
+    });
+  }
 }

--- a/lib/contactHandler.ts
+++ b/lib/contactHandler.ts
@@ -1,3 +1,5 @@
+import { Resend } from 'resend';
+
 export type ContactPayload = {
   name?: string;
   email?: string;
@@ -13,7 +15,24 @@ export type ContactResult = {
 const isValid = (value: unknown, min = 1, max = 5000) =>
   typeof value === 'string' && value.trim().length >= min && value.trim().length <= max;
 
-export const handleContactSubmission = (payload: ContactPayload): ContactResult => {
+const escapeHtml = (value: string) =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+
+const getEmailConfig = () => {
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  const toEmail = process.env.CONTACT_TO_EMAIL?.trim();
+  const fromEmail =
+    process.env.CONTACT_FROM_EMAIL?.trim() ?? 'Portfolio Contact <onboarding@resend.dev>';
+
+  return { apiKey, toEmail, fromEmail };
+};
+
+export const handleContactSubmission = async (payload: ContactPayload): Promise<ContactResult> => {
   if (payload.website) {
     return { status: 200, body: { ok: true, message: 'Message received.' } };
   }
@@ -29,18 +48,58 @@ export const handleContactSubmission = (payload: ContactPayload): ContactResult 
     };
   }
 
-  console.log('Contact form stub submission:', {
-    name: payload.name,
-    email: payload.email,
-    message: payload.message,
-    receivedAt: new Date().toISOString(),
+  const { apiKey, toEmail, fromEmail } = getEmailConfig();
+
+  if (!apiKey || !toEmail) {
+    console.error('Contact form misconfigured: RESEND_API_KEY and CONTACT_TO_EMAIL are required.');
+    return {
+      status: 503,
+      body: {
+        ok: false,
+        message: 'Contact form is not configured yet. Please email me directly.',
+      },
+    };
+  }
+
+  const name = payload.name!.trim();
+  const email = payload.email!.trim();
+  const message = payload.message!.trim();
+
+  const resend = new Resend(apiKey);
+  const { data, error } = await resend.emails.send({
+    from: fromEmail,
+    to: [toEmail],
+    replyTo: email,
+    subject: `Portfolio contact from ${name}`,
+    text: `New message from your portfolio contact form.\n\nName: ${name}\nEmail: ${email}\n\nMessage:\n${message}`,
+    html: `
+      <p><strong>New message from your portfolio contact form.</strong></p>
+      <p><strong>Name:</strong> ${escapeHtml(name)}</p>
+      <p><strong>Email:</strong> ${escapeHtml(email)}</p>
+      <p><strong>Message:</strong></p>
+      <p>${escapeHtml(message).replaceAll('\n', '<br />')}</p>
+    `,
+    tags: [{ name: 'source', value: 'portfolio-contact-form' }],
   });
+
+  if (error) {
+    console.error('Resend contact form error:', error);
+    return {
+      status: 502,
+      body: {
+        ok: false,
+        message: 'Unable to send your message right now. Please try again or email me directly.',
+      },
+    };
+  }
+
+  console.log('Contact form email sent:', { id: data?.id, to: toEmail, from: email });
 
   return {
     status: 200,
     body: {
       ok: true,
-      message: 'Email delivery not configured yet. Your message was captured in the server log.',
+      message: 'Thanks — your message has been sent. I will get back to you soon.',
     },
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "resend": "^6.14.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -25,6 +26,9 @@
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.18.2",
         "vite": "^6.0.5"
+      },
+      "engines": {
+        "node": "24.x"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1651,6 +1655,12 @@
         "win32"
       ]
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@ts-morph/common": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.11.1.tgz",
@@ -2986,6 +2996,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -3874,6 +3890,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
@@ -4019,6 +4041,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.14.0.tgz",
+      "integrity": "sha512-jVdpUgOoWGLjaP64lo8KwzHT9gY4w6Dl8c36CIb2F+ayYOMLr3khqs8xrNjXM2k19b+lPoj0VWQFhVNLiToBjA==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve-from": {
@@ -4200,6 +4243,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "resend": "^6.14.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useState } from 'react';
 import { Section } from '@/components/ui/Section';
+import { CONTACT_EMAIL } from '@/config/site';
 
 type FormState = {
   name: string;
@@ -66,7 +67,7 @@ export const Contact = () => {
       setStatus({ type: 'success', message: payload.message ?? 'Message sent.' });
       setForm(initialState);
     } catch {
-      setStatus({ type: 'error', message: 'Unable to send right now. Please email me directly.' });
+      setStatus({ type: 'error', message: `Unable to send right now. Please email me at ${CONTACT_EMAIL}.` });
     } finally {
       setIsSubmitting(false);
     }
@@ -87,7 +88,7 @@ export const Contact = () => {
           >
             LinkedIn
           </a>
-          <a href="mailto:hello@example.com">Email</a>
+          <a href={`mailto:${CONTACT_EMAIL}`}>Email</a>
         </aside>
 
         <div className="contact-form-wrap">

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,0 +1,1 @@
+export const CONTACT_EMAIL = import.meta.env.VITE_CONTACT_EMAIL ?? 'hello@dtriv.tech';

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,3 +1,11 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_CONTACT_EMAIL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 declare module '*.css';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,7 +38,7 @@ const contactDevMiddleware = async (req: IncomingMessage, res: ServerResponse, n
 
   try {
     const payload = await readJsonBody(req);
-    const result = handleContactSubmission(payload);
+    const result = await handleContactSubmission(payload);
     res.statusCode = result.status;
     res.setHeader('Content-Type', 'application/json');
     res.end(JSON.stringify(result.body));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the contact form to deliver submissions to your inbox via **Resend**, which is the recommended approach for Vercel-hosted sites (serverless-friendly, no SMTP, good deliverability).

## What changed

- Implemented real email delivery in `lib/contactHandler.ts` using the Resend SDK
- Refactored `api/contact.ts` to use the shared async handler (removes duplicate stub logic)
- Added environment variable support for `RESEND_API_KEY`, `CONTACT_TO_EMAIL`, and `CONTACT_FROM_EMAIL`
- Updated the contact section mailto link and error fallback to use `VITE_CONTACT_EMAIL` / `hello@dtriv.tech`
- Added `.env.example` and README setup instructions

## Setup required (Vercel)

After merging, add these in **Vercel → Project Settings → Environment Variables** and redeploy:

| Variable | Example |
|----------|---------|
| `RESEND_API_KEY` | `re_...` from [resend.com/api-keys](https://resend.com/api-keys) |
| `CONTACT_TO_EMAIL` | Your personal inbox |
| `CONTACT_FROM_EMAIL` | `Portfolio Contact <contact@dtriv.tech>` (requires domain verification in Resend) |
| `VITE_CONTACT_EMAIL` | Optional — email shown in the mailto link |

**Resend domain setup:** Verify `dtriv.tech` at [resend.com/domains](https://resend.com/domains) so outbound mail is sent from your domain rather than the test-only `onboarding@resend.dev` address.

## Behavior

- Form submissions are emailed to `CONTACT_TO_EMAIL` with `replyTo` set to the visitor's address
- Honeypot field and server-side validation are preserved
- Returns a clear error if env vars are missing or Resend fails
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65f8babc-d0d4-4210-be2f-89d6f4e72223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65f8babc-d0d4-4210-be2f-89d6f4e72223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

